### PR TITLE
WIP: chef solo resource artifact collection

### DIFF
--- a/test/fabric/wordpress.py
+++ b/test/fabric/wordpress.py
@@ -1,3 +1,4 @@
+import os
 import re
 from fabric.api import env, run, hide, task
 from envassert import detect, file, group, package, port, process, service, \
@@ -52,5 +53,10 @@ def check():
 @task
 def artifacts():
     env.platform_family = detect.detect()
-    logs = run("/bin/bash -c 'echo /tmp/heat_chef/*-*-*-*-*/{bootstrap,clone_kitchen,run_chef}.log'").split()
+    logbasenames = ["bootstrap", "clone_kitchen", "run_chef"]
+    logdirs = run("/bin/bash -c 'echo /tmp/heat_chef/*-*-*-*-*'").split()
+    logs = []
+    for logdir in logdirs:
+        for basename in logbasenames:
+            logs.append(os.path.join(logdir, basename + ".log"))
     get_artifacts(logs)

--- a/test/fabric/wordpress.py
+++ b/test/fabric/wordpress.py
@@ -2,7 +2,7 @@ import re
 from fabric.api import env, run, hide, task
 from envassert import detect, file, group, package, port, process, service, \
     user
-
+from hot.utils.test import get_artifacts, http_check, local_http_check
 
 def wordpress_is_responding():
     with hide('running', 'stdout'):
@@ -47,3 +47,10 @@ def check():
     assert service.is_enabled('vsftpd'), 'vsftpd service not enabled'
 
     assert wordpress_is_responding(), 'Wordpress did not respond as expected.'
+
+
+@task
+def artifacts():
+    env.platform_family = detect.detect()
+    logs = run("/bin/bash -c 'echo /tmp/heat_chef/*-*-*-*-*/{bootstrap,clone_kitchen,run_chef}.log'").split()
+    get_artifacts(logs)

--- a/tests.yaml
+++ b/tests.yaml
@@ -15,6 +15,7 @@ test-cases:
             key_filename: tmp/private_key
             hosts: { get_output: server_ip } # Fetch from output-list of stack
             tasks:
+              - artifacts
               - check
             abort_on_prompts: True
             connection_attempts: 3


### PR DESCRIPTION
A first pass at a chef solo provider artifact collection task.

I would prefer to use fabric's `get()` function alone, but its glob expansion is not nearly as flexible as bash's, so I just use bash to expand the glob.

fabric's `get()` can't handle globs of the form `/tmp/heat_chef/*-*-*-*-*/{bootstrap,clone_kitchen,run_chef}.log'`, but bash doesn't blink at this and gives me what I expect.

I've reviewed chef.log for this deployment and it doesn't reveal any sensitive info afaict, but I've left it out for further review by other eyes before inclusion. I'd like that log in the artifacts if possible as it's occasionally invaluable for diagnosing problems quickly.